### PR TITLE
Centralize match status helpers

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,6 +13,12 @@ import { supabase } from '@/lib/supabase';
 import { useAuth } from '@/contexts/AuthContext';
 import { Player } from '@/types/database';
 import { convertPlayersDataToArray } from '@/lib/playerUtils';
+import {
+  formatDate,
+  formatTime,
+  getStatusColor,
+  getStatusText,
+} from '@/lib/statusUtils';
 import { router } from 'expo-router';
 import { 
   Calendar, 
@@ -205,44 +211,6 @@ export default function DashboardScreen() {
     fetchDashboardData();
   };
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('nl-NL', {
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  };
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'inProgress':
-      case 'paused':
-        return '#10B981';
-      case 'upcoming':
-        return '#F59E0B';
-      case 'completed':
-        return '#6B7280';
-      default:
-        return '#6B7280';
-    }
-  };
-
-  const getStatusText = (status: string) => {
-    switch (status) {
-      case 'inProgress':
-        return 'LIVE';
-      case 'paused':
-        return 'GEPAUZEERD';
-      case 'upcoming':
-        return 'AANKOMEND';
-      case 'completed':
-        return 'AFGEROND';
-      default:
-        return status.toUpperCase();
-    }
-  };
 
 
   const getMatchInfo = (match: RecentMatch) => {
@@ -375,7 +343,7 @@ export default function DashboardScreen() {
                       <View style={styles.matchDetailItem}>
                         <Clock size={12} color="#6B7280" />
                         <Text style={styles.matchDetailText}>
-                          {formatDate(match.date)}
+                          {formatDate(match.date)} • {formatTime(match.date)}
                         </Text>
                       </View>
                       

--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -11,6 +11,12 @@ import {
 import { supabase } from '@/lib/supabase';
 import { useAuth } from '@/contexts/AuthContext';
 import { router } from 'expo-router';
+import {
+  formatDate,
+  formatTime,
+  getStatusColor,
+  getStatusText,
+} from '@/lib/statusUtils';
 import { 
   Calendar, 
   MapPin, 
@@ -130,51 +136,6 @@ export default function MatchesScreen() {
     fetchMatches();
   };
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('nl-NL', {
-      weekday: 'short',
-      month: 'short',
-      day: 'numeric',
-    });
-  };
-
-  const formatTime = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleTimeString('nl-NL', {
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  };
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'inProgress':
-      case 'paused':
-        return '#10B981';
-      case 'upcoming':
-        return '#F59E0B';
-      case 'completed':
-        return '#6B7280';
-      default:
-        return '#6B7280';
-    }
-  };
-
-  const getStatusText = (status: string) => {
-    switch (status) {
-      case 'inProgress':
-        return 'LIVE';
-      case 'paused':
-        return 'GEPAUZEERD';
-      case 'upcoming':
-        return 'AANKOMEND';
-      case 'completed':
-        return 'AFGEROND';
-      default:
-        return status.toUpperCase();
-    }
-  };
 
   const getFilterCount = (filter: FilterType) => {
     switch (filter) {

--- a/lib/statusUtils.ts
+++ b/lib/statusUtils.ts
@@ -1,0 +1,45 @@
+export function getStatusColor(status: string): string {
+  switch (status) {
+    case 'inProgress':
+    case 'paused':
+      return '#10B981';
+    case 'upcoming':
+      return '#F59E0B';
+    case 'completed':
+      return '#6B7280';
+    default:
+      return '#6B7280';
+  }
+}
+
+export function getStatusText(status: string): string {
+  switch (status) {
+    case 'inProgress':
+      return 'LIVE';
+    case 'paused':
+      return 'GEPAUZEERD';
+    case 'upcoming':
+      return 'AANKOMEND';
+    case 'completed':
+      return 'AFGEROND';
+    default:
+      return status.toUpperCase();
+  }
+}
+
+export function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('nl-NL', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function formatTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleTimeString('nl-NL', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}


### PR DESCRIPTION
## Summary
- add `lib/statusUtils.ts` for match status & date helpers
- use helpers in dashboard and matches tabs

## Testing
- `npm run lint` *(fails: 403 Forbidden due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_686231e2c8c88320a069566edb5cabb2