### PR TITLE
Refactor position naming utility

### DIFF
--- a/app/match/[id].tsx
+++ b/app/match/[id].tsx
@@ -30,7 +30,7 @@ import {
   Shield
 } from 'lucide-react-native';
 import TimeControl from '../components/match/TimeControl';
-import { getPositionColor, getPositionDisplayName } from '@/lib/playerPositions';
+import { getPositionColor, getPositionDisplayName, getDutchPositionName } from '@/lib/playerPositions';
 import { styles } from '../styles/match';
 import TimeDisplay from '../components/match/TimeDisplay';
 import SubstitutionBanner from '../components/match/SubstitutionBanner';
@@ -634,13 +634,6 @@ export default function MatchScreen() {
     }
   };
 
-  const getDutchPositionName = (pos: FormationPosition): string => {
-    if (pos.label_translations && pos.label_translations.nl) {
-      return pos.label_translations.nl;
-    }
-    
-    return pos.dutch_name || pos.name || 'Onbekend';
-  };
 
   const makePositionSubstitution = (targetPosition: FormationPosition) => {
     if (!match || !selectedPosition) return;

--- a/components/FieldView.tsx
+++ b/components/FieldView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Player, FormationPosition } from '@/types/database';
+import { getDutchPositionName } from '@/lib/playerPositions';
 
 interface Props {
   positions: FormationPosition[];
@@ -83,15 +84,6 @@ export default function FieldView({
     return undefined;
   };
 
-  const getDutchPositionName = (pos: FormationPosition): string => {
-    // First try to get from label_translations.nl
-    if (pos.label_translations && pos.label_translations.nl) {
-      return pos.label_translations.nl;
-    }
-    
-    // Fallback to dutch_name, then name
-    return pos.dutch_name || pos.name || 'Onbekend';
-  };
 
   const getPositionColor = (pos: FormationPosition, player?: Player): string => {
     if (highlightPosition === pos.id) return '#EF4444'; // Red for highlighted

--- a/lib/playerPositions.ts
+++ b/lib/playerPositions.ts
@@ -75,3 +75,13 @@ export function getPositionDisplayName(position: string) {
       return position || 'Onbekend';
   }
 }
+
+import { FormationPosition } from '@/types/database';
+
+export function getDutchPositionName(pos: FormationPosition): string {
+  if (pos.label_translations && pos.label_translations.nl) {
+    return pos.label_translations.nl;
+  }
+
+  return pos.dutch_name || pos.name || 'Onbekend';
+}


### PR DESCRIPTION
## Summary
- create `getDutchPositionName` in `lib/playerPositions`
- reuse `getDutchPositionName` in `FieldView` and match screen

## Testing
- `npm run lint` *(fails: 403 Forbidden)*
- `npx tsc --noEmit` *(fails: cannot find modules and many TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68624217a6448320b5157c9fa669a973