### PR TITLE
Centralize UUID validation

### DIFF
--- a/app/match/[id].tsx
+++ b/app/match/[id].tsx
@@ -29,6 +29,7 @@ import {
   Eye,
   Shield
 } from 'lucide-react-native';
+import { isValidUUID } from '@/lib/validation';
 import TimeControl from '../components/match/TimeControl';
 import { getPositionColor, getPositionDisplayName, getDutchPositionName } from '@/lib/playerPositions';
 import { styles } from '../styles/match';
@@ -204,13 +205,6 @@ export default function MatchScreen() {
       cards: 0,
     }));
   };
-
-  const isValidUUID = (str: string): boolean => {
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-    return uuidRegex.test(str);
-  };
-
-  const convertPositionsToArray = (positions: any): FormationPosition[] => {
     if (Array.isArray(positions)) {
       return positions;
     }

--- a/lib/matchEventLogger.ts
+++ b/lib/matchEventLogger.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/lib/supabase';
 import { Player } from '@/types/database';
 import { MatchesLive } from '@/types/database';
+import { isValidUUID } from "@/lib/validation";
 
 export interface MatchEventLog {
   match_id: string;
@@ -150,9 +151,7 @@ class MatchEventLogger {
       return false;
     }
     
-    // Basic UUID validation
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(matchId)) {
+    if (!isValidUUID(matchId)) {
       console.error('❌ Invalid UUID format for match ID:', matchId);
       return false;
     }

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,5 @@
+export function isValidUUID(id: string): boolean {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(id);
+}
+


### PR DESCRIPTION
## Summary
- add `isValidUUID` helper under `lib/validation.ts`
- reuse helper in `matchEventLogger` and match screen

## Testing
- `npm run lint` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6862483dd7248320a6d78ea4e27f1481