### PR TITLE
Remove duplicate formatTime

### DIFF
--- a/app/match/[id].tsx
+++ b/app/match/[id].tsx
@@ -39,6 +39,14 @@ import ViewModeToggle from '../components/match/ViewModeToggle';
 
 const { width: screenWidth } = Dimensions.get('window');
 
+function formatTime(seconds: number) {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes.toString().padStart(2, '0')}:${remainingSeconds
+    .toString()
+    .padStart(2, '0')}`;
+}
+
 interface Formation {
   id: string;
   key: string;
@@ -90,11 +98,6 @@ function CompactPlayerCard({
   onPress,
   formation,
 }: CompactPlayerCardProps) {
-  const formatTime = (seconds: number) => {
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = seconds % 60;
-    return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
-  };
 
   const getCardStyle = () => {
     if (isSelected) return styles.selectedPlayerCard;
@@ -749,11 +752,6 @@ export default function MatchScreen() {
     Object.keys(match.substitution_schedule).length > 0;
 
   // Timeline functions
-  const formatTime = (seconds: number) => {
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = seconds % 60;
-    return `${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`;
-  };
 
   const getCurrentQuarter = (time: number) => {
     return Math.floor(time / (15 * 60)) + 1;


### PR DESCRIPTION
## Summary
- centralize `formatTime` in match screen
- update `CompactPlayerCard` and timeline logic to use global `formatTime`

## Testing
- `npm run lint` *(fails: 403 Forbidden when fetching expo)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules and JSX flag errors)*

------
https://chatgpt.com/codex/tasks/task_e_68625cd9eca48320b98282fd83307811