### PR TITLE
Refactor live player list

### DIFF
--- a/app/components/match/LivePlayerCard.tsx
+++ b/app/components/match/LivePlayerCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { Shield } from 'lucide-react-native';
 import { Player } from '@/types/database';
-import { styles as matchStyles } from '@/styles/match';
+import { styles as matchStyles } from '../../styles/match';
 import { getPositionColor } from '@/lib/playerPositions';
 
 interface Props {

--- a/app/components/match/LivePlayerCard.tsx
+++ b/app/components/match/LivePlayerCard.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { Shield } from 'lucide-react-native';
+import { Player } from '@/types/database';
+import { styles as matchStyles } from '@/styles/match';
+import { getPositionColor } from '@/lib/playerPositions';
+
+interface Props {
+  player: Player;
+  positionName: string;
+  onPress?: () => void;
+  selected?: boolean;
+  bench?: boolean;
+  numberColor?: string;
+  conditionColor?: string;
+  subLabel?: string;
+}
+
+export default function LivePlayerCard({
+  player,
+  positionName,
+  onPress,
+  selected,
+  bench,
+  numberColor,
+  conditionColor = '#10B981',
+  subLabel,
+}: Props) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={[
+        matchStyles.livePlayerCard,
+        bench && matchStyles.benchPlayerCard,
+        selected && (bench ? matchStyles.selectedBenchPlayerCard : matchStyles.selectedFieldPlayerCard),
+      ]}
+      accessibilityLabel={`Speler ${player.name}`}
+    >
+      <View style={[matchStyles.livePlayerNumberBadge, { backgroundColor: numberColor || getPositionColor(player.position) }]}>
+        <Text style={matchStyles.livePlayerNumberText}>#{player.number}</Text>
+      </View>
+      <View style={matchStyles.livePlayerInfo}>
+        {bench && <Text style={matchStyles.reserveLabel}>Reserve</Text>}
+        <Text style={matchStyles.livePlayerPosition}>{positionName}</Text>
+        <View style={matchStyles.livePlayerDetails}>
+          <Text style={matchStyles.livePlayerName}>{player.name}</Text>
+          {subLabel && <Text style={matchStyles.livePlayerSubTime}>{subLabel}</Text>}
+        </View>
+      </View>
+      <View style={matchStyles.livePlayerMeta}>
+        <View style={[matchStyles.conditionDot, { backgroundColor: conditionColor }]} />
+        {(player.isGoalkeeper || player.position?.toLowerCase().includes('goalkeeper')) && (
+          <Shield size={12} color="#EF4444" />
+        )}
+      </View>
+    </TouchableOpacity>
+  );
+}


### PR DESCRIPTION
## Summary
- extract `LivePlayerCard` component for reusability
- use new card for active and bench players
- add helper `getPositionOrder` to centralise formation sorting

## Testing
- `npm run lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68626f1d754483209c4eb4253b82844e