### PR TITLE
Display next position in live player card

### DIFF
--- a/app/components/match/LivePlayerCard.tsx
+++ b/app/components/match/LivePlayerCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
-import { Shield } from 'lucide-react-native';
+import { Shield, ArrowRight } from 'lucide-react-native';
 import { Player } from '@/types/database';
 import { styles as matchStyles } from '../../styles/match';
 import { getPositionColor } from '@/lib/playerPositions';
@@ -14,6 +14,7 @@ interface Props {
   numberColor?: string;
   conditionColor?: string;
   subLabel?: string;
+  nextPositionName?: string;
 }
 
 export default function LivePlayerCard({
@@ -25,6 +26,7 @@ export default function LivePlayerCard({
   numberColor,
   conditionColor = '#10B981',
   subLabel,
+  nextPositionName,
 }: Props) {
   return (
     <TouchableOpacity
@@ -45,6 +47,12 @@ export default function LivePlayerCard({
         <View style={matchStyles.livePlayerDetails}>
           <Text style={matchStyles.livePlayerName}>{player.name}</Text>
           {subLabel && <Text style={matchStyles.livePlayerSubTime}>{subLabel}</Text>}
+          {nextPositionName && (
+            <View style={matchStyles.nextPositionContainer}>
+              <ArrowRight size={10} color="#6B7280" />
+              <Text style={matchStyles.nextPositionText}>{nextPositionName}</Text>
+            </View>
+          )}
         </View>
       </View>
       <View style={matchStyles.livePlayerMeta}>

--- a/app/components/match/LivePlayerCard.tsx
+++ b/app/components/match/LivePlayerCard.tsx
@@ -13,7 +13,6 @@ interface Props {
   bench?: boolean;
   numberColor?: string;
   conditionColor?: string;
-  subLabel?: string;
   nextPositionName?: string;
 }
 
@@ -25,7 +24,6 @@ export default function LivePlayerCard({
   bench,
   numberColor,
   conditionColor = '#10B981',
-  subLabel,
   nextPositionName,
 }: Props) {
   return (
@@ -46,7 +44,6 @@ export default function LivePlayerCard({
         <Text style={matchStyles.livePlayerPosition}>{positionName}</Text>
         <View style={matchStyles.livePlayerDetails}>
           <Text style={matchStyles.livePlayerName}>{player.name}</Text>
-          {subLabel && <Text style={matchStyles.livePlayerSubTime}>{subLabel}</Text>}
           {nextPositionName && (
             <View style={matchStyles.nextPositionContainer}>
               <ArrowRight size={10} color="#6B7280" />

--- a/app/match/[id].tsx
+++ b/app/match/[id].tsx
@@ -960,7 +960,6 @@ export default function MatchScreen() {
                             onPress={() => handlePlayerPress(player, true)}
                             selected={selectedPlayer?.id === player.id}
                             numberColor={getPositionColor(player.position)}
-                            subLabel="Start"
                             nextPositionName={getNextPositionForPlayer(player.id, currentTime) || undefined}
                           />
                         ))
@@ -976,7 +975,6 @@ export default function MatchScreen() {
                             onPress={() => handlePlayerPress(player, true)}
                             selected={selectedPlayer?.id === player.id}
                             numberColor={getPositionColorForSchedule(position)}
-                            subLabel={formatTime(timelineEvents.find(e => e.player.id === player.id && e.position === position)?.time || 0)}
                             nextPositionName={getNextPositionForPlayer(player.id, currentTime) || undefined}
                             conditionColor={
                               player.condition && player.condition >= 80 ? '#10B981' :
@@ -1019,6 +1017,7 @@ export default function MatchScreen() {
                             onPress={() => handlePlayerPress(player, false)}
                             selected={selectedPlayer?.id === player.id}
                             numberColor={getPositionColor(player.position)}
+                            nextPositionName={getNextPositionForPlayer(player.id, currentTime) || undefined}
                             conditionColor="#6B7280"
                           />
                         ))

--- a/app/match/[id].tsx
+++ b/app/match/[id].tsx
@@ -810,8 +810,17 @@ export default function MatchScreen() {
     
     // Return players not currently on field
     const reserves = allPlayers.filter(player => !activePlayerIds.has(player.id));
-    
+
     return reserves;
+  };
+
+  const getNextPositionForPlayer = (playerId: string, time: number) => {
+    const nextEvent = timelineEvents.find(event =>
+      event.time > time && event.player.id === playerId
+    );
+    if (!nextEvent) return null;
+    const pos = formation?.positions.find(p => p.name === nextEvent.position);
+    return pos?.label_translations?.nl || nextEvent.position;
   };
   const getPositions = () => {
     return Object.keys(parsedSchedule).sort();
@@ -930,6 +939,7 @@ export default function MatchScreen() {
                             selected={selectedPlayer?.id === player.id}
                             numberColor={getPositionColor(player.position)}
                             subLabel="Start"
+                            nextPositionName={getNextPositionForPlayer(player.id, currentTime) || undefined}
                           />
                         ))
                     ) : (
@@ -945,6 +955,7 @@ export default function MatchScreen() {
                             selected={selectedPlayer?.id === player.id}
                             numberColor={getPositionColorForSchedule(position)}
                             subLabel={formatTime(timelineEvents.find(e => e.player.id === player.id && e.position === position)?.time || 0)}
+                            nextPositionName={getNextPositionForPlayer(player.id, currentTime) || undefined}
                             conditionColor={
                               player.condition && player.condition >= 80 ? '#10B981' :
                               player.condition >= 60 ? '#F59E0B' : '#EF4444'

--- a/app/styles/match.ts
+++ b/app/styles/match.ts
@@ -309,11 +309,6 @@ export const styles = StyleSheet.create({
       fontFamily: 'Inter-Medium',
       color: '#6B7280',
     },
-    livePlayerSubTime: {
-      fontSize: 9,
-      fontFamily: 'Inter-Regular',
-      color: '#10B981',
-    },
     nextPositionContainer: {
       flexDirection: 'row',
       alignItems: 'center',

--- a/app/styles/match.ts
+++ b/app/styles/match.ts
@@ -314,6 +314,16 @@ export const styles = StyleSheet.create({
       fontFamily: 'Inter-Regular',
       color: '#10B981',
     },
+    nextPositionContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 2,
+    },
+    nextPositionText: {
+      fontSize: 8,
+      fontFamily: 'Inter-Regular',
+      color: '#6B7280',
+    },
     livePlayerMeta: {
       flexDirection: 'row',
       alignItems: 'center',


### PR DESCRIPTION
## Summary
- include next position text and arrow in `LivePlayerCard`
- style next-position label
- compute next position from substitution schedule

## Testing
- `npm run lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6862742c432c8320ba86fb16051d0688