### PR TITLE
Add matches_live_events table

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ To lint the project:
 npm run lint
 ```
 
+## Database Planning
+
+For upcoming features we maintain design notes in `supabase/docs`. See
+[`matches_live_events_plan.md`](supabase/docs/matches_live_events_plan.md) for
+details about storing each live match event. The table is implemented in the
+migration
+[`20250630223000_create_matches_live_events.sql`](supabase/migrations/20250630223000_create_matches_live_events.sql).
+
 ## Building for Web
 
 ```

--- a/lib/liveEventLogger.ts
+++ b/lib/liveEventLogger.ts
@@ -1,0 +1,156 @@
+import { supabase } from '@/lib/supabase';
+import { isValidUUID } from '@/lib/validation';
+import { Player } from '@/types/database';
+
+export type MatchEventAction =
+  | 'swap'
+  | 'goal'
+  | 'card'
+  | 'substitution'
+  | 'match_start'
+  | 'match_end'
+  | 'quarter_start'
+  | 'quarter_end'
+  | 'formation_change'
+  | 'player_selection'
+  | 'timeout'
+  | 'injury'
+  | 'penalty_corner'
+  | 'penalty_stroke'
+  | 'green_card'
+  | 'yellow_card'
+  | 'red_card'
+  | 'score_change';
+
+interface LogEventParams {
+  matchId: string;
+  action: MatchEventAction;
+  description: string;
+  matchTime?: number;
+  quarter?: number;
+  playerId?: string;
+  teamId?: string;
+  metadata?: Record<string, any>;
+}
+
+export async function logEvent(params: LogEventParams): Promise<void> {
+  const { matchId, action, description, matchTime, quarter, playerId, teamId, metadata } = params;
+  if (!isValidUUID(matchId)) {
+    console.error('Invalid match ID for event log:', matchId);
+    return;
+  }
+
+  const { error } = await supabase.from('matches_live_events').insert({
+    match_id: matchId,
+    player_id: playerId,
+    team_id: teamId,
+    action,
+    description,
+    match_time: matchTime,
+    quarter,
+    metadata,
+  });
+
+  if (error) {
+    console.error('Failed to log match event:', error);
+  }
+}
+
+export async function logSubstitution(
+  matchId: string,
+  playerIn: Player,
+  playerOut: Player,
+  matchTime: number,
+  quarter: number,
+): Promise<void> {
+  await logEvent({
+    matchId,
+    playerId: playerIn.id,
+    action: 'substitution',
+    description: `Substitution: ${playerIn.name} in for ${playerOut.name}`,
+    matchTime,
+    quarter,
+    metadata: {
+      player_in: { id: playerIn.id, name: playerIn.name, number: playerIn.number },
+      player_out: { id: playerOut.id, name: playerOut.name, number: playerOut.number },
+    },
+  });
+}
+
+export async function logPlayerSwap(
+  matchId: string,
+  player1: Player,
+  player2: Player,
+  matchTime: number,
+  quarter: number,
+  fromPosition?: string,
+  toPosition?: string,
+): Promise<void> {
+  await logEvent({
+    matchId,
+    playerId: player1.id,
+    action: 'swap',
+    description: `${player1.name} swapped with ${player2.name}`,
+    matchTime,
+    quarter,
+    metadata: {
+      player_in: { id: player1.id, name: player1.name, number: player1.number },
+      player_out: { id: player2.id, name: player2.name, number: player2.number },
+      from_position: fromPosition,
+      to_position: toPosition,
+    },
+  });
+}
+
+export async function logScoreChange(
+  matchId: string,
+  matchTime: number,
+  quarter: number,
+  newHome: number,
+  newAway: number,
+  prevHome: number,
+  prevAway: number,
+  team?: 'home' | 'away',
+): Promise<void> {
+  await logEvent({
+    matchId,
+    action: 'score_change',
+    description: `Score updated to ${newHome}-${newAway}`,
+    matchTime,
+    quarter,
+    metadata: {
+      new_score: { home: newHome, away: newAway },
+      previous_score: { home: prevHome, away: prevAway },
+      team_scored: team,
+    },
+  });
+}
+
+export async function logMatchStart(matchId: string): Promise<void> {
+  await logEvent({
+    matchId,
+    action: 'match_start',
+    description: 'Match started',
+    matchTime: 0,
+    quarter: 1,
+  });
+}
+
+export async function logMatchEnd(
+  matchId: string,
+  matchTime: number,
+  quarter: number,
+  finalHome: number,
+  finalAway: number,
+): Promise<void> {
+  await logEvent({
+    matchId,
+    action: 'match_end',
+    description: `Match ended with score ${finalHome}-${finalAway}`,
+    matchTime,
+    quarter,
+    metadata: {
+      final_score: { home: finalHome, away: finalAway },
+    },
+  });
+}

--- a/supabase/docs/matches_live_events_plan.md
+++ b/supabase/docs/matches_live_events_plan.md
@@ -1,0 +1,34 @@
+# matches_live_events Table Plan
+
+This plan outlines the structure and purpose of the upcoming `matches_live_events` table. The table will be used to persist all live events during a match for detailed post–match analysis and statistics.
+
+## Purpose
+- Store each match event as a single row rather than inside the `matches_live.events` JSON array.
+- Provide an audit trail of every action in a match: substitutions, goals, cards, quarter starts/ends, etc.
+- Allow efficient queries for analytics and reporting (per player, match, or event type).
+
+## Proposed Columns
+| Column         | Type                       | Description                                                            |
+|---------------|---------------------------|------------------------------------------------------------------------|
+| `id`          | `uuid` PK                 | Unique identifier for the event.                                       |
+| `match_id`    | `uuid` FK `matches(id)`   | Reference to the match this event belongs to.                          |
+| `player_id`   | `uuid` FK `players(id)`   | Optional reference to the player involved in the event.                |
+| `team_id`     | `uuid` FK `teams(id)`     | Team responsible for the event (helps when player_id is null).         |
+| `action`      | `text`                    | Type of event (goal, substitution, card, etc.).                        |
+| `description` | `text`                    | Human readable description of the event.                               |
+| `match_time`  | `integer`                 | Match clock time when the event occurred (in seconds).                 |
+| `quarter`     | `integer`                 | Match quarter number.                                                  |
+| `metadata`    | `jsonb`                   | Additional structured info (e.g. card color, position coordinates).    |
+| `created_at`  | `timestamptz`             | Timestamp when the event was recorded.                                 |
+
+## Indexes & Constraints
+- Index on `match_id` for quick retrieval of events for a match.
+- Index on `(match_id, player_id)` to filter events for a specific player in a match.
+- GIN index on `metadata` for searching JSON fields when necessary.
+- Foreign keys to ensure data integrity with related tables (`matches`, `players`, `teams`).
+
+## Usage Considerations
+- Use this table for any analytics or historical reporting rather than the transient `matches_live.events` column.
+- A background job can periodically copy events from the JSON array into this table, or future code may write directly to this table when events occur.
+- Functions such as `get_match_events_summary` and `get_player_event_stats` can be updated later to query this table for better performance.
+

--- a/supabase/migrations/20250630223000_create_matches_live_events.sql
+++ b/supabase/migrations/20250630223000_create_matches_live_events.sql
@@ -1,0 +1,50 @@
+/*
+  # Create matches_live_events table for analytics
+
+  1. Changes
+    - Create matches_live_events table to store each match event in a row
+    - Add indexes on match_id, (match_id, player_id) and metadata
+    - Enable row level security and create basic policy
+
+  2. Notes
+    - Table is intended for post-match analysis
+    - Metadata JSONB column allows flexible event details
+*/
+
+-- Create matches_live_events table
+CREATE TABLE IF NOT EXISTS matches_live_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  match_id uuid NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
+  player_id uuid REFERENCES players(id),
+  team_id uuid REFERENCES teams(id),
+  action text NOT NULL,
+  description text,
+  match_time integer,
+  quarter integer,
+  metadata jsonb,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Add indexes for efficient queries
+CREATE INDEX IF NOT EXISTS idx_mle_match_id ON matches_live_events(match_id);
+CREATE INDEX IF NOT EXISTS idx_mle_match_player ON matches_live_events(match_id, player_id);
+CREATE INDEX IF NOT EXISTS idx_mle_metadata_gin ON matches_live_events USING GIN (metadata);
+
+-- Enable RLS and basic policy mirroring matches_live
+ALTER TABLE matches_live_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their team's events"
+  ON matches_live_events
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM matches m
+      JOIN teams t ON m.team_id = t.id
+      WHERE m.id = matches_live_events.match_id
+      AND t.coach @> JSON_BUILD_ARRAY(JSON_BUILD_OBJECT('id', auth.uid()::text))
+    )
+  );
+
+-- Document the table
+COMMENT ON TABLE matches_live_events IS 'Stores each live match event as a row for analytics';


### PR DESCRIPTION
## Summary
- document migration location in README
- create matches_live_events table with indexes and RLS policy
- log match events to the new table from the app

## Testing
- `npm run lint` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68630a7fd41c832092c25bc9732dea67